### PR TITLE
Fix filter variable name in api

### DIFF
--- a/src/app/containers/List/index.js
+++ b/src/app/containers/List/index.js
@@ -57,8 +57,8 @@ class List extends React.Component {
         <Helmet>
           <title>
             {renderedListMeta.title +
-              (this.props.list.filters.author
-                ? this.props.list.filters.author.name
+              (this.props.list.filter.author
+                ? this.props.list.filter.author.name
                 : null)}
           </title>
           <meta name="description" content={renderedListMeta.description} />
@@ -67,23 +67,23 @@ class List extends React.Component {
           {this.props.header
             ? this.props.header
             : <ListHeader>
-                {this.props.list.filters.author
+                {this.props.list.filter.author
                   ? <q>
                       <em>
                         {renderedListMeta.title}
-                        {this.props.list.filters.author.name ? " " : null}
-                        {this.props.list.filters.author.name
+                        {this.props.list.filter.author.name ? " " : null}
+                        {this.props.list.filter.author.name
                           ? <ModalDispatch
                               with={{
                                 request: {
                                   url:
                                     ROUTE_AUTHOR_API +
                                     "/" +
-                                    this.props.list.filters.author.id
+                                    this.props.list.filter.author.id
                                 }
                               }}
                             >
-                              {this.props.list.filters.author.name}
+                              {this.props.list.filter.author.name}
                             </ModalDispatch>
                           : this.props.location.pathname.includes("/author/") &&
                             "␆"}

--- a/src/reducers/listReducer.js
+++ b/src/reducers/listReducer.js
@@ -1,6 +1,6 @@
 const INITIAL_STATE = {
   status: "loading",
-  filters: {
+  filter: {
     tags: [],
     author: {}
   },


### PR DESCRIPTION
API back-end has changed object name to `filter` from `filters` that was in the mockup. This fixes the issue that arised from this.