### PR TITLE
Hotfix: patch sluggish touch events on mobile

### DIFF
--- a/src/app/components/List/index.js
+++ b/src/app/components/List/index.js
@@ -70,7 +70,11 @@ export default props => {
                       tag: item.tag
                     })
                   }
-                  onMouseOver={props.userIntent}
+                  onMouseOver={
+                    "ontouchstart" in document.documentElement
+                      ? null
+                      : props.userIntent
+                  }
                 >
                   <section>
                     <figure>

--- a/src/app/components/Nav/index.js
+++ b/src/app/components/Nav/index.js
@@ -19,7 +19,11 @@ import { NavLink, NavIndexLink, NavItem } from "./styles"
 // return
 export const CommonNav = props => {
   return (
-    <ul onMouseOver={props.userIntent}>
+    <ul
+      onMouseOver={
+        "ontouchstart" in document.documentElement ? null : props.userIntent
+      }
+    >
       <NavItem>
         <NavLink to={"/photo-essays"}>
           <span>Photo Essays</span>


### PR DESCRIPTION
Although **v0.10.0** isn't ready yet, this is a critical fix that needs to go out as soon as possible. An error caused really shitty touch response on the website that was meant to make interactivity and loading faster on desktop. This patch fixes it.