### PR TITLE
Streamline image author

### DIFF
--- a/src/app/core/components/controls/Card/index.js
+++ b/src/app/core/components/controls/Card/index.js
@@ -10,12 +10,14 @@ import Subscribe from "../../../../user/components/forms/Subscribe"
 export default props => {
   return (
     <CardPopup style={props.style}>
-      <CardHeader
-        error={props.error}
-        stubborn={props.stubborn}
-        buttons={props.buttons}
-        title={props.title}
-      />
+      {!props.headless && (
+        <CardHeader
+          error={props.error}
+          stubborn={props.stubborn}
+          buttons={props.buttons}
+          title={props.title}
+        />
+      )}
       <CardFigure image={props.image} text={props.text} />
       {props.subscribeForm && [
         <Subscribe

--- a/src/app/core/components/controls/Modal/components/ModalOverlay.js
+++ b/src/app/core/components/controls/Modal/components/ModalOverlay.js
@@ -50,6 +50,7 @@ const ModalOverlay = props => {
         text={props.modal.info.text}
         error={props.modal.info.error && props.modal.info.error}
         stubborn={props.modal.info.stubborn}
+        headless={props.modal.info.headless}
         buttons={props.modal.info.buttons}
         subscribeForm={props.modal.info.subscribeForm}
         subscribeFormLocation={props.modal.info.subscribeFormLocation}

--- a/src/app/core/components/vignettes/Picture/components/Ficaption.js
+++ b/src/app/core/components/vignettes/Picture/components/Ficaption.js
@@ -53,27 +53,16 @@ export default props => {
   return (
     <figcaption
       style={
-        props.nocaption && {
-          borderBottom: "8px solid #2c2c2c",
-          height: 0,
-          overflow: "hidden"
-        }
+        props.nocaption || (props.readOnly && !props.caption)
+          ? {
+              borderBottom: "8px solid #2c2c2c",
+              height: 0,
+              overflow: "hidden"
+            }
+          : null
       }
     >
-      {props.author ? (
-        <Figcaption>
-          {props.children}
-          {props.readOnly ? <CaptionAuthor author={props.author} /> : null}
-        </Figcaption>
-      ) : (
-        <Figcaption {...props}>
-          {props.children}
-          {!props.noAuthor &&
-            props.readOnly && (
-              <CaptionAuthor> Finding image author…</CaptionAuthor>
-            )}
-        </Figcaption>
-      )}
+      <Figcaption>{props.children}</Figcaption>
     </figcaption>
   )
 }

--- a/src/app/core/components/vignettes/Picture/components/Ficaption.js
+++ b/src/app/core/components/vignettes/Picture/components/Ficaption.js
@@ -2,7 +2,6 @@ import React from "react"
 import styled, { css } from "styled-components"
 
 import Caption from "../../Caption"
-import CaptionAuthor from "./CaptionAuthor"
 
 const captionBlock = css`
   ${props => props.theme.size.breakpoint.min.l`

--- a/src/app/core/components/vignettes/Picture/components/Figure.js
+++ b/src/app/core/components/vignettes/Picture/components/Figure.js
@@ -106,6 +106,11 @@ const Figure = styled.figure`
     }
     z-index: ${props => props.theme.layer.up + 1};
   }
+  ${props =>
+    props.feature &&
+    !props.caption &&
+    props.foldSpacer &&
+    `margin-bottom: -1em;`}
   textarea {
     ${styles};
     font-size: inherit !important;
@@ -123,9 +128,8 @@ export default props => {
         }
       />
       <Figcaption
+        caption={props.caption}
         nocaption={props.nocaption}
-        author={props.author}
-        noAuthor={props.noAuthor}
         readOnly={props.readOnly}
       >
         {props.children}

--- a/src/app/core/components/vignettes/Picture/index.js
+++ b/src/app/core/components/vignettes/Picture/index.js
@@ -1,5 +1,4 @@
 import { connect } from "react-redux"
-import { getFroth } from "@roast-cms/image-froth"
 import Loadable from "react-loadable"
 import React from "react"
 
@@ -126,29 +125,10 @@ class Picture extends React.PureComponent {
     if (caption !== this.state.caption) {
       this.setState({ caption })
     }
-
-    const authorRequet = this.state.authorCard.id
-    console.log(1, authorRequet)
-    if (authorRequet && nextProps.picture[authorRequet]) {
-      this.setState({
-        authorCard: {
-          info: nextProps.picture[authorRequet].info,
-          id: authorRequet,
-          url: "/author"
-        }
-      })
-      console.log(2, this.state.authorCard)
-    }
   }
   handleGetAuthor = src => {
     if (!src || !this.props.readOnly) return
     this.props.getPictureInfo(src)
-    this.setState({
-      authorCard: {
-        id: src
-      }
-    })
-    this.props.setModal(this.state.authorCard)
   }
   render = () => {
     const { attributes, node, isSelected, editor, parent } = this.props

--- a/src/app/core/store/actions-picture.js
+++ b/src/app/core/store/actions-picture.js
@@ -2,8 +2,10 @@ import { getFroth } from "@roast-cms/image-froth"
 import axios from "axios"
 
 import { CARD_ERRORS } from "../constants/messages-"
+import { ROUTE_API_AUTHORS } from "../constants/routes-article"
 import { ROUTE_API_IMAGES } from "../../user/constants/routes-submission"
 import { TEXT_ERRORS } from "../../constants"
+import { fetchModal, setModal } from "./actions-modal"
 import { makeAPIRequest } from "../../utils"
 
 const UNKNOWN_AUTHOR = (id, error) => {
@@ -37,14 +39,38 @@ export const getPictureInfo = src => {
     axios(makeAPIRequest(request))
       .then(response => {
         response.data.status === "ok"
-          ? dispatch({
-              type: "PICTURE.GET_INFO",
-              payload: {
-                info: response.data.info,
-                status: response.data.status,
-                id
-              }
-            })
+          ? dispatch(
+              setModal(
+                {
+                  info: {
+                    buttons: [
+                      {
+                        to: "#about-author",
+                        onClick: event => {
+                          event.preventDefault()
+                          dispatch(
+                            fetchModal({
+                              url:
+                                ROUTE_API_AUTHORS +
+                                "/" +
+                                response.data.info.author.id
+                            })
+                          )
+                        },
+                        text: `Image by ${response.data.info.author.name}`,
+                        inverse: true
+                      }
+                    ],
+                    headless: true
+                  },
+                  status: response.data.status,
+                  id
+                },
+                {
+                  url: "hints/image-author"
+                }
+              )
+            )
           : dispatch(UNKNOWN_AUTHOR(id))
       })
       .catch(error => dispatch(UNKNOWN_AUTHOR(id, error)))


### PR DESCRIPTION
Now image author names no longer appear under photographs. Image authors can be recalled when clicking on photographs.