### PR TITLE
Unpublishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "copy": "^0.3.1",
-    "husky": "^0.14.3",
+    "husky": "^1.0.1",
     "jest-localstorage-mock": "^2.2.0",
     "jest-styled-components": "^5.0.1",
     "lint-staged": "^7.1.0",

--- a/src/app/admin/components/controls/ArticleControls/components/EditorialControls.js
+++ b/src/app/admin/components/controls/ArticleControls/components/EditorialControls.js
@@ -44,22 +44,25 @@ export default props => {
           </ButtonStripItem>
         ) : (
           [
-            <ButtonStripItem
-              key="ButtonStrip_Item_reject"
-              onClick={props.reject}
-              inverse={props.editor.reject.id === props.article.id}
-              style={{
-                minWidth: "6em",
-                display: props.article.status !== "scheduled" ? "block" : "none"
-              }}
-            >
-              <span role="img" aria-label="(Un)Locked button">
-                {props.stateAllowReject
-                  ? TEXT_EMOJIS.UNLOCKED
-                  : TEXT_EMOJIS.LOCKED}
-              </span>{" "}
-              Reject
-            </ButtonStripItem>,
+            props.article.status !== "unpublished" ? (
+              <ButtonStripItem
+                key="ButtonStrip_Item_reject"
+                onClick={props.reject}
+                inverse={props.editor.reject.id === props.article.id}
+                style={{
+                  minWidth: "6em",
+                  display:
+                    props.article.status !== "scheduled" ? "block" : "none"
+                }}
+              >
+                <span role="img" aria-label="(Un)Locked button">
+                  {props.stateAllowReject
+                    ? TEXT_EMOJIS.UNLOCKED
+                    : TEXT_EMOJIS.LOCKED}
+                </span>{" "}
+                Reject
+              </ButtonStripItem>
+            ) : null,
             <ButtonStripItem
               right
               inverse={props.statePublishControls}
@@ -74,7 +77,11 @@ export default props => {
               key="ButtonStrip_Item_publish"
             >
               {props.article.status !== "scheduled"
-                ? "Publish"
+                ? `${
+                    props.article.status === "unpublished"
+                      ? "Republish"
+                      : "Publish"
+                  }`
                 : "Edit Schedule"}
             </ButtonStripItem>
           ]

--- a/src/app/admin/components/controls/ArticleControls/components/EditorialControls.js
+++ b/src/app/admin/components/controls/ArticleControls/components/EditorialControls.js
@@ -29,61 +29,56 @@ export default props => {
           </span>{" "}
           Edit
         </ButtonStripItem>
-        {props.article.status === "published"
-          ? [
-              <ButtonStripItem
-                key="ButtonStrip_Item_update"
-                onClick={props.sync}
-              >
-                <span role="img" aria-label="(Un)Locked button">
-                  {props.stateAllowSync
-                    ? TEXT_EMOJIS.UNLOCKED
-                    : TEXT_EMOJIS.LOCKED}
-                </span>{" "}
-                Sync
-              </ButtonStripItem>,
-              <ButtonStripItem key="ButtonStrip_Item_unpublish" right>
-                Unpublish
-              </ButtonStripItem>
-            ]
-          : [
-              <ButtonStripItem
-                key="ButtonStrip_Item_reject"
-                onClick={props.reject}
-                inverse={props.editor.reject.id === props.article.id}
-                style={{
-                  minWidth: "6em",
-                  display:
-                    props.article.status !== "scheduled" ? "block" : "none"
-                }}
-              >
-                <span role="img" aria-label="(Un)Locked button">
-                  {props.stateAllowReject
-                    ? TEXT_EMOJIS.UNLOCKED
-                    : TEXT_EMOJIS.LOCKED}
-                </span>{" "}
-                Reject
-              </ButtonStripItem>,
-              <ButtonStripItem
-                right
-                inverse={props.statePublishControls}
-                style={
-                  props.article.status === "scheduled"
-                    ? { minWidth: "8em" }
-                    : {}
-                }
-                onClick={
-                  props.article.status !== "scheduled"
-                    ? props.showPublishControls
-                    : null
-                }
-                key="ButtonStrip_Item_publish"
-              >
-                {props.article.status !== "scheduled"
-                  ? "Publish"
-                  : "Edit Schedule"}
-              </ButtonStripItem>
-            ]}
+        {props.article.status === "published" ? (
+          <ButtonStripItem
+            key="ButtonStrip_Item_unpublish"
+            onClick={props.unpublish}
+            right
+          >
+            <span role="img" aria-label="(Un)Locked button">
+              {props.stateAllowUnpublish
+                ? TEXT_EMOJIS.UNLOCKED
+                : TEXT_EMOJIS.LOCKED}
+            </span>{" "}
+            Unpublish
+          </ButtonStripItem>
+        ) : (
+          [
+            <ButtonStripItem
+              key="ButtonStrip_Item_reject"
+              onClick={props.reject}
+              inverse={props.editor.reject.id === props.article.id}
+              style={{
+                minWidth: "6em",
+                display: props.article.status !== "scheduled" ? "block" : "none"
+              }}
+            >
+              <span role="img" aria-label="(Un)Locked button">
+                {props.stateAllowReject
+                  ? TEXT_EMOJIS.UNLOCKED
+                  : TEXT_EMOJIS.LOCKED}
+              </span>{" "}
+              Reject
+            </ButtonStripItem>,
+            <ButtonStripItem
+              right
+              inverse={props.statePublishControls}
+              style={
+                props.article.status === "scheduled" ? { minWidth: "8em" } : {}
+              }
+              onClick={
+                props.article.status !== "scheduled"
+                  ? props.showPublishControls
+                  : null
+              }
+              key="ButtonStrip_Item_publish"
+            >
+              {props.article.status !== "scheduled"
+                ? "Publish"
+                : "Edit Schedule"}
+            </ButtonStripItem>
+          ]
+        )}
       </div>
     </ButtonStrip>
   )

--- a/src/app/admin/components/controls/ArticleControls/components/__snapshots__/index.test.js.snap
+++ b/src/app/admin/components/controls/ArticleControls/components/__snapshots__/index.test.js.snap
@@ -44,6 +44,7 @@ ShallowWrapper {
         </Unknown>
         <Unknown
                 onClick={undefined}
+                right={true}
         >
                 <span
                         aria-label="(Un)Locked button"
@@ -52,11 +53,6 @@ ShallowWrapper {
                         🔐
                 </span>
                  
-                Sync
-        </Unknown>
-        <Unknown
-                right={true}
-        >
                 Unpublish
         </Unknown>
 </div>,
@@ -92,25 +88,19 @@ ShallowWrapper {
              
             Edit
 </Unknown>,
-          Array [
-            <Unknown
-              onClick={undefined}
+          <Unknown
+            onClick={undefined}
+            right={true}
 >
-              <span
-                            aria-label="(Un)Locked button"
-                            role="img"
-              >
-                            🔐
-              </span>
-               
-              Sync
+            <span
+                        aria-label="(Un)Locked button"
+                        role="img"
+            >
+                        🔐
+            </span>
+             
+            Unpublish
 </Unknown>,
-            <Unknown
-              right={true}
->
-              Unpublish
-</Unknown>,
-          ],
         ],
       },
       "ref": null,
@@ -158,7 +148,7 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "ButtonStrip_Item_update",
+          "key": "ButtonStrip_Item_unpublish",
           "nodeType": "function",
           "props": Object {
             "children": Array [
@@ -169,9 +159,10 @@ ShallowWrapper {
                 🔐
 </span>,
               " ",
-              "Sync",
+              "Unpublish",
             ],
             "onClick": undefined,
+            "right": true,
           },
           "ref": null,
           "rendered": Array [
@@ -189,20 +180,8 @@ ShallowWrapper {
               "type": "span",
             },
             " ",
-            "Sync",
+            "Unpublish",
           ],
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": "ButtonStrip_Item_unpublish",
-          "nodeType": "function",
-          "props": Object {
-            "children": "Unpublish",
-            "right": true,
-          },
-          "ref": null,
-          "rendered": "Unpublish",
           "type": [Function],
         },
       ],
@@ -237,6 +216,7 @@ ShallowWrapper {
           </Unknown>
           <Unknown
                     onClick={undefined}
+                    right={true}
           >
                     <span
                               aria-label="(Un)Locked button"
@@ -245,11 +225,6 @@ ShallowWrapper {
                               🔐
                     </span>
                      
-                    Sync
-          </Unknown>
-          <Unknown
-                    right={true}
-          >
                     Unpublish
           </Unknown>
 </div>,
@@ -285,25 +260,19 @@ ShallowWrapper {
                
               Edit
 </Unknown>,
-            Array [
-              <Unknown
-                onClick={undefined}
+            <Unknown
+              onClick={undefined}
+              right={true}
 >
-                <span
-                                aria-label="(Un)Locked button"
-                                role="img"
-                >
-                                🔐
-                </span>
-                 
-                Sync
+              <span
+                            aria-label="(Un)Locked button"
+                            role="img"
+              >
+                            🔐
+              </span>
+               
+              Unpublish
 </Unknown>,
-              <Unknown
-                right={true}
->
-                Unpublish
-</Unknown>,
-            ],
           ],
         },
         "ref": null,
@@ -351,7 +320,7 @@ ShallowWrapper {
           },
           Object {
             "instance": null,
-            "key": "ButtonStrip_Item_update",
+            "key": "ButtonStrip_Item_unpublish",
             "nodeType": "function",
             "props": Object {
               "children": Array [
@@ -362,9 +331,10 @@ ShallowWrapper {
                   🔐
 </span>,
                 " ",
-                "Sync",
+                "Unpublish",
               ],
               "onClick": undefined,
+              "right": true,
             },
             "ref": null,
             "rendered": Array [
@@ -382,20 +352,8 @@ ShallowWrapper {
                 "type": "span",
               },
               " ",
-              "Sync",
+              "Unpublish",
             ],
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": "ButtonStrip_Item_unpublish",
-            "nodeType": "function",
-            "props": Object {
-              "children": "Unpublish",
-              "right": true,
-            },
-            "ref": null,
-            "rendered": "Unpublish",
             "type": [Function],
           },
         ],

--- a/src/app/admin/components/controls/ArticleControls/index.js
+++ b/src/app/admin/components/controls/ArticleControls/index.js
@@ -10,13 +10,14 @@ import { withRouter } from "react-router"
 import { CARD_DIALOGUES } from "../../../constants/messages-admin"
 import { ROUTE_URL_SUBMISSIONS } from "../../../../core/constants/routes-article"
 import { TEXT_EMOJIS } from "../../../../constants"
-import { getSubmissionOrArticleRoute } from "../../../../core/utils/routes-article"
 import {
+  deleteSubmission,
   publishSubmission,
   rejectSubmission,
-  deleteSubmission,
-  setStatus
+  setStatus,
+  unpublishArticle
 } from "../../../store/actions-editor"
+import { getSubmissionOrArticleRoute } from "../../../../core/utils/routes-article"
 import { setComposerHeader } from "../../../../user/store/actions-composer"
 import { setModal } from "../../../../core/store/actions-modal"
 import { storeHeaderState } from "../../../../user/utils/actions-submission"
@@ -90,7 +91,7 @@ class ArticleControls extends React.PureComponent {
       this.props.setModal(CARD_DIALOGUES.UNPUBLISH(this.handleUnlockFunction))
       return
     }
-    alert("unpublish")
+    this.props.unpublishArticle(this.props.article.id, this.props.history)
   }
   handleRejection = event => {
     event.preventDefault()
@@ -221,6 +222,9 @@ const mapDispatchToProps = dispatch => {
     },
     deleteSubmission: (id, history) => {
       dispatch(deleteSubmission(id, history))
+    },
+    unpublishArticle: (id, history) => {
+      dispatch(unpublishArticle(id, history))
     },
     setComposerHeader: value => {
       dispatch(setComposerHeader(value))

--- a/src/app/admin/components/controls/ArticleControls/index.js
+++ b/src/app/admin/components/controls/ArticleControls/index.js
@@ -36,8 +36,8 @@ class ArticleControls extends React.PureComponent {
       allowOverwrite: false,
       allowReject: false,
       allowPublish: false,
-      allowDelete: false
-      // allowSync: false,
+      allowDelete: false,
+      allowUnpublish: false
     }
   }
   componentWillReceiveProps = nextProps => {
@@ -84,6 +84,14 @@ class ArticleControls extends React.PureComponent {
     )
     this.props.history.push("/submit/compose")
   }
+  handleUnpublish = event => {
+    event.preventDefault()
+    if (!this.state.allowUnpublish) {
+      this.props.setModal(CARD_DIALOGUES.UNPUBLISH(this.handleUnlockFunction))
+      return
+    }
+    alert("unpublish")
+  }
   handleRejection = event => {
     event.preventDefault()
     if (!this.state.allowReject) {
@@ -127,9 +135,6 @@ class ArticleControls extends React.PureComponent {
       publishAs: tag === this.state.publishAs ? "" : tag
     })
   }
-  handleSync = event => {
-    event.preventDefault()
-  }
 
   render = () => {
     return [
@@ -142,12 +147,12 @@ class ArticleControls extends React.PureComponent {
         article={this.props.article}
         editor={this.props.editor}
         edit={this.handleEdit}
-        sync={this.handleSync}
+        unpublish={this.handleUnpublish}
         reject={this.handleRejection}
         showPublishControls={this.handlePublishControls}
         stateAllowOverwrite={this.state.allowOverwrite}
-        stateAllowSync={this.state.allowSync}
         stateAllowReject={this.state.allowReject}
+        stateAllowUnpublish={this.state.allowUnpublish}
         statePublishControls={this.state.publishControls}
       />,
       <Byline
@@ -186,7 +191,8 @@ class ArticleControls extends React.PureComponent {
       >
         <span style={{ fontStyle: "normal" }} role="img" aria-label="Notice">
           {this.state.allowDelete ? TEXT_EMOJIS.UNLOCKED : TEXT_EMOJIS.LOCKED}
-        </span>You can also{" "}
+        </span>
+        You can also{" "}
         <Link to="#delete" onClick={this.handleDelete}>
           delte
         </Link>{" "}

--- a/src/app/admin/constants/messages-admin.js
+++ b/src/app/admin/constants/messages-admin.js
@@ -81,6 +81,24 @@ export const CARD_DIALOGUES = {
       id: "hints/publish-submission"
     }
   },
+  UNPUBLISH: unlockFunction => {
+    return {
+      info: {
+        title: "Are You Sure?",
+        text:
+          "Please confirm that you want this article UNPUBLISHED. This will trigger an immediate RSS feed update and will affect sitemap, SEO, and create a 404 page status.",
+        buttons: [
+          NEVERMIND_BUTTON,
+          {
+            to: "#unpublish",
+            onClick: event => unlockFunction(event, "allowUnpublish"),
+            text: TEXT_EMOJIS.KEY + " Unlock"
+          }
+        ]
+      },
+      id: "hints/unpublish-submission"
+    }
+  },
   SAVE_EDITS: {
     info: {
       title: "Notes for Editors",

--- a/src/app/admin/constants/messages-admin.js
+++ b/src/app/admin/constants/messages-admin.js
@@ -127,9 +127,16 @@ export const CARD_ALERTS = {
   DELETED_SUCCESSFULLY: {
     info: {
       title: "Successfuly Deleted Submission",
-      text: "Done. Submission DELETED from database."
+      text: "Done. Submission REMOVED from database."
     },
     id: "hints/reject-submission"
+  },
+  UNPUBLISHED_SUCCESSFULLY: {
+    info: {
+      title: "Successfuly Unpublished Article",
+      text: "Done. Article REMOVED from publication."
+    },
+    id: "hints/unpublish-submission"
   },
   SCHEDULED: {
     info: {

--- a/src/app/admin/store/actions-editor.js
+++ b/src/app/admin/store/actions-editor.js
@@ -1,6 +1,7 @@
 import axios from "axios"
 
 import { CARD_ALERTS } from "../constants/messages-admin"
+import { ROUTE_API_ARTICLES } from "../../core/constants/routes-article"
 import { ROUTE_API_SUBMISSIONS } from "../constants/routes-admin"
 import { ROUTE_URL_USER_LANDING } from "../../user/constants/routes-session"
 import { makeAPIRequest } from "../../utils"
@@ -56,6 +57,25 @@ export const deleteSubmission = (submissionId, history) => {
       .then(response => {
         dispatch(setModal(CARD_ALERTS.DELETED_SUCCESSFULLY))
         dispatch(history.push(ROUTE_URL_USER_LANDING))
+      })
+      .catch(error => {
+        console.log(error)
+      })
+  }
+}
+export const unpublishArticle = (submissionId, history) => {
+  return dispatch => {
+    const request = {
+      url: `${ROUTE_API_ARTICLES}/${submissionId}`,
+      method: "delete",
+      headers: {
+        Authorization: "JWT " + localStorage.getItem("token")
+      }
+    }
+    axios(makeAPIRequest(request))
+      .then(response => {
+        dispatch(setModal(CARD_ALERTS.UNPUBLISHED_SUCCESSFULLY))
+        dispatch(history.push("/"))
       })
       .catch(error => {
         console.log(error)

--- a/src/app/core/constants/messages-list.js
+++ b/src/app/core/constants/messages-list.js
@@ -4,6 +4,7 @@ import { ROUTE_URL_USER_LANDING } from "../../user/constants/routes-session"
 export const TEXT_STATUS_LABELS = {
   pending: "In Queue",
   rejected: "Not Published",
+  unpublished: "Unpublished",
   scheduled: "Scheduled",
   published: "Published"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,6 +1745,10 @@ ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
 
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+
 ci-job-number@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ci-job-number/-/ci-job-number-0.3.0.tgz#34bdd114b0dece1960287bd40a57051041a2a800"
@@ -2116,6 +2120,14 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
 cosmiconfig@^5.0.2, cosmiconfig@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cosmiconfig@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
@@ -3701,6 +3713,10 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -4155,13 +4171,20 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-husky@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+husky@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.1.tgz#749bc6b3a14bdc9cab73d8cc827b92fcd691fac6"
   dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
+    cosmiconfig "^5.0.6"
+    execa "^0.9.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.2.1"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
 
 iconv-lite@0.4.19:
   version "0.4.19"
@@ -4372,6 +4395,12 @@ is-ci@^1.0.10:
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
     ci-info "^1.0.0"
+
+is-ci@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  dependencies:
+    ci-info "^1.5.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -5960,10 +5989,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -6480,9 +6505,21 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
+
 please-upgrade-node@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz#7b9eaeca35aa4a43d6ebdfd10616c042f9a83acc"
+  dependencies:
+    semver-compare "^1.0.0"
+
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
   dependencies:
     semver-compare "^1.0.0"
 
@@ -7292,6 +7329,14 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -7634,6 +7679,10 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
@@ -7906,6 +7955,10 @@ size-limit@^0.19.0:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
 
 slate-auto-replace@^0.9.0:
   version "0.9.1"
@@ -8335,10 +8388,6 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
- Allow editors and admins to "unpublish" articles. Unpublished articles are removed from index and all will return 404s.
- If an article that's being unpublished doesn't have a linked submission, one will be created.
- Unpublished articles can be "republished," which will place them back into the same space as before (not at the top)
- No email notifications will be sent to anyone upon these actions.