### PR TITLE
Fix preload screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analog-cafe",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "A film photography magazine",
   "license": "MPL-2.0",
   "private": true,

--- a/src/app/core/components/controls/ArticleActions/components/Options.js
+++ b/src/app/core/components/controls/ArticleActions/components/Options.js
@@ -1,6 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 
+import { DOCUMENT_PLACEHOLDER } from "../../../../constants/messages-article"
 import { GA, makeFroth } from "../../../../../utils"
 import { ROUTE_URL_ARTICLES } from "../../../../constants/routes-article"
 import CardCaption from "../../Card/components/CardCaption"
@@ -13,12 +14,14 @@ import Subscribe from "../../../../../user/components/forms/Subscribe"
 
 const nextArticlePreload = nextArticle => {
   return {
+    status: "loading",
     title: nextArticle.title,
     subtitle: nextArticle.subtitle,
     authors: nextArticle.authors,
     slug: nextArticle.slug,
     poster: nextArticle.poster,
-    tag: nextArticle.tag
+    tag: nextArticle.tag,
+    content: DOCUMENT_PLACEHOLDER
   }
 }
 

--- a/src/app/core/components/controls/ArticleActions/components/Options.js
+++ b/src/app/core/components/controls/ArticleActions/components/Options.js
@@ -1,9 +1,9 @@
 import React from "react"
 import styled from "styled-components"
 
-import { DOCUMENT_PLACEHOLDER } from "../../../../constants/messages-article"
 import { GA, makeFroth } from "../../../../../utils"
 import { ROUTE_URL_ARTICLES } from "../../../../constants/routes-article"
+import { preloadConstructor } from "../../../../utils/routes-article"
 import CardCaption from "../../Card/components/CardCaption"
 import CardHeader from "../../Card/components/CardHeader"
 import CardIntegrated from "../../Card/components/CardIntegrated"
@@ -11,19 +11,6 @@ import Link from "../../Link"
 import LinkButton from "../../Button/components/LinkButton"
 import Placeholder from "../../../vignettes/Picture/components/Placeholder"
 import Subscribe from "../../../../../user/components/forms/Subscribe"
-
-const nextArticlePreload = nextArticle => {
-  return {
-    status: "loading",
-    title: nextArticle.title,
-    subtitle: nextArticle.subtitle,
-    authors: nextArticle.authors,
-    slug: nextArticle.slug,
-    poster: nextArticle.poster,
-    tag: nextArticle.tag,
-    content: DOCUMENT_PLACEHOLDER
-  }
-}
 
 export const CardColumns = styled.div`
   display: flex;
@@ -101,7 +88,7 @@ export default props => {
                 to={ROUTE_URL_ARTICLES + "/" + props.nextArticle.slug}
                 onClick={() => {
                   props.nextArticleHeading(
-                    nextArticlePreload(props.nextArticle)
+                    preloadConstructor(props.article, props.nextArticle)
                   )
                   GA.event({
                     category: "Navigation",
@@ -124,7 +111,9 @@ export default props => {
               style={{ margin: 0 }}
               to={ROUTE_URL_ARTICLES + "/" + props.nextArticle.slug}
               onClick={() => {
-                props.nextArticleHeading(nextArticlePreload(props.nextArticle))
+                props.nextArticleHeading(
+                  preloadConstructor(props.article, props.nextArticle)
+                )
                 GA.event({
                   category: "Navigation",
                   action: "ActionsCard.next_article_button"

--- a/src/app/core/components/pages/Article/index.js
+++ b/src/app/core/components/pages/Article/index.js
@@ -3,6 +3,7 @@ import LazyLoad from "react-lazyload"
 import Loadable from "react-loadable"
 import React from "react"
 
+import { DOCUMENT_PLACEHOLDER } from "../../../constants/messages-article"
 import { HOST_PROD, HOST_PROTOCOL } from "../../../../constants"
 import { ROUTE_TAGS } from "../../../constants/routes-list"
 import {
@@ -224,12 +225,14 @@ class Article extends React.Component {
                   }
                   nextArticleHeading={nextArticleHeading =>
                     this.props.setArticlePage({
+                      status: "loading",
                       title: nextArticleHeading.title,
                       subtitle: nextArticleHeading.subtitle,
                       authors: nextArticleHeading.authors,
                       slug: nextArticleHeading.slug,
                       poster: nextArticleHeading.poster,
-                      tag: nextArticleHeading.tag
+                      tag: nextArticleHeading.tag,
+                      content: DOCUMENT_PLACEHOLDER
                     })
                   }
                 />

--- a/src/app/core/components/pages/Article/index.js
+++ b/src/app/core/components/pages/Article/index.js
@@ -3,7 +3,6 @@ import LazyLoad from "react-lazyload"
 import Loadable from "react-loadable"
 import React from "react"
 
-import { DOCUMENT_PLACEHOLDER } from "../../../constants/messages-article"
 import { HOST_PROD, HOST_PROTOCOL } from "../../../../constants"
 import { ROUTE_TAGS } from "../../../constants/routes-list"
 import {
@@ -15,7 +14,10 @@ import {
   setArticlePage,
   setArticleSelectoin
 } from "../../../store/actions-article"
-import { getSubmissionOrArticleRoute } from "../../../utils/routes-article"
+import {
+  getSubmissionOrArticleRoute,
+  preloadConstructor
+} from "../../../utils/routes-article"
 import { getTitleFromSlug } from "../../../utils/messages-"
 import ArticleHeader from "./components/ArticleHeader"
 import ArticleSection from "./components/ArticleSection"
@@ -116,8 +118,12 @@ class Article extends React.Component {
       })
       return
     }
-    const selection = window.getSelection()
-    const range = selection.getRangeAt(0).cloneRange()
+    const selection = window.getSelection && window.getSelection()
+    if (!selection || selection.rangeCount <= 0) return
+    const range = selection.getRangeAt(0)
+      ? selection.getRangeAt(0).cloneRange()
+      : undefined
+    if (!range) return
     let rects, rect, leftOffset, topOffset
     if (range.getClientRects) {
       range.collapse(true)
@@ -213,6 +219,7 @@ class Article extends React.Component {
               >
                 <ArticleActions
                   user={this.props.user}
+                  article={this.props.article}
                   subscribeFormCallback={this.handleSubscribeFormCallback}
                   subscribeForm={this.state.subscribeForm}
                   nextArticle={this.props.article.next}
@@ -224,16 +231,9 @@ class Article extends React.Component {
                     this.props.article.date && this.props.article.date.updated
                   }
                   nextArticleHeading={nextArticleHeading =>
-                    this.props.setArticlePage({
-                      status: "loading",
-                      title: nextArticleHeading.title,
-                      subtitle: nextArticleHeading.subtitle,
-                      authors: nextArticleHeading.authors,
-                      slug: nextArticleHeading.slug,
-                      poster: nextArticleHeading.poster,
-                      tag: nextArticleHeading.tag,
-                      content: DOCUMENT_PLACEHOLDER
-                    })
+                    this.props.setArticlePage(
+                      preloadConstructor(this.props.article, nextArticleHeading)
+                    )
                   }
                 />
               </LazyLoad>

--- a/src/app/core/components/pages/List/components/ListBlock.js
+++ b/src/app/core/components/pages/List/components/ListBlock.js
@@ -1,6 +1,7 @@
 import LazyLoad from "react-lazyload"
 import React from "react"
 
+import { DOCUMENT_PLACEHOLDER } from "../../../../constants/messages-article"
 import {
   ROUTE_URL_ARTICLES,
   ROUTE_URL_SUBMISSIONS
@@ -40,12 +41,14 @@ export default props => {
                   }
                   onClick={() =>
                     props.nextArticleHeading({
+                      status: "loading",
                       title: item.title,
                       subtitle: item.subtitle,
                       authors: item.authors,
                       slug: item.slug,
                       poster: item.poster,
-                      tag: item.tag
+                      tag: item.tag,
+                      content: DOCUMENT_PLACEHOLDER
                     })
                   }
                   onMouseOver={

--- a/src/app/core/components/pages/List/components/ListBlock.js
+++ b/src/app/core/components/pages/List/components/ListBlock.js
@@ -41,7 +41,7 @@ export default props => {
                   }
                   onClick={() =>
                     props.nextArticleHeading(
-                      preloadConstructor(item, props.article)
+                      preloadConstructor(props.article, item)
                     )
                   }
                   onMouseOver={

--- a/src/app/core/components/pages/List/components/ListBlock.js
+++ b/src/app/core/components/pages/List/components/ListBlock.js
@@ -1,12 +1,12 @@
 import LazyLoad from "react-lazyload"
 import React from "react"
 
-import { DOCUMENT_PLACEHOLDER } from "../../../../constants/messages-article"
 import {
   ROUTE_URL_ARTICLES,
   ROUTE_URL_SUBMISSIONS
 } from "../../../../constants/routes-article"
 import { makeFroth } from "../../../../../utils"
+import { preloadConstructor } from "../../../../utils/routes-article"
 import Bleed from "./Bleed"
 import Link from "../../../controls/Link"
 import ListCaption from "./ListCaption"
@@ -40,16 +40,9 @@ export default props => {
                       item.slug
                   }
                   onClick={() =>
-                    props.nextArticleHeading({
-                      status: "loading",
-                      title: item.title,
-                      subtitle: item.subtitle,
-                      authors: item.authors,
-                      slug: item.slug,
-                      poster: item.poster,
-                      tag: item.tag,
-                      content: DOCUMENT_PLACEHOLDER
-                    })
+                    props.nextArticleHeading(
+                      preloadConstructor(item, props.article)
+                    )
                   }
                   onMouseOver={
                     "ontouchstart" in document.documentElement

--- a/src/app/core/components/pages/List/index.js
+++ b/src/app/core/components/pages/List/index.js
@@ -4,6 +4,7 @@ import React from "react"
 
 import { withRouter } from "react-router"
 
+import { DOCUMENT_PLACEHOLDER } from "../../../constants/messages-article"
 import { GA } from "../../../../utils"
 import {
   ROUTE_API_LIST,
@@ -105,12 +106,14 @@ class List extends React.PureComponent {
             items={this.props.list.items}
             nextArticleHeading={nextArticleHeading =>
               this.props.setArticlePage({
+                status: "loading",
                 title: nextArticleHeading.title,
                 subtitle: nextArticleHeading.subtitle,
                 tag: nextArticleHeading.tag,
                 authors: nextArticleHeading.authors,
                 slug: nextArticleHeading.slug,
-                poster: nextArticleHeading.poster
+                poster: nextArticleHeading.poster,
+                content: DOCUMENT_PLACEHOLDER
               })
             }
             private={this.props.private}

--- a/src/app/core/components/pages/List/index.js
+++ b/src/app/core/components/pages/List/index.js
@@ -4,7 +4,6 @@ import React from "react"
 
 import { withRouter } from "react-router"
 
-import { DOCUMENT_PLACEHOLDER } from "../../../constants/messages-article"
 import { GA } from "../../../../utils"
 import {
   ROUTE_API_LIST,
@@ -12,6 +11,7 @@ import {
 } from "../../../constants/routes-list"
 import { fetchListPage } from "../../../store/actions-list"
 import { getListMeta } from "../../../utils/messages-list"
+import { preloadConstructor } from "../../../utils/routes-article"
 import { setArticlePage } from "../../../store/actions-article"
 import { setUserIntent } from "../../../../user/store/actions-user"
 import Button from "../../controls/Button/components/Button"
@@ -105,20 +105,14 @@ class List extends React.PureComponent {
             status={this.props.list.status}
             items={this.props.list.items}
             nextArticleHeading={nextArticleHeading =>
-              this.props.setArticlePage({
-                status: "loading",
-                title: nextArticleHeading.title,
-                subtitle: nextArticleHeading.subtitle,
-                tag: nextArticleHeading.tag,
-                authors: nextArticleHeading.authors,
-                slug: nextArticleHeading.slug,
-                poster: nextArticleHeading.poster,
-                content: DOCUMENT_PLACEHOLDER
-              })
+              this.props.setArticlePage(
+                preloadConstructor(this.props.article, nextArticleHeading)
+              )
             }
             private={this.props.private}
             isAdmin={this.props.isAdmin}
             userIntent={this.handleUserIntent}
+            article={this.props.article}
           />
         )}
         {parseInt(this.props.list.page.total, 0) > 1 &&
@@ -140,7 +134,8 @@ class List extends React.PureComponent {
 const mapStateToProps = state => {
   return {
     list: state.list,
-    user: state.user
+    user: state.user,
+    article: state.article
   }
 }
 const mapDispatchToProps = dispatch => {

--- a/src/app/core/utils/routes-article.js
+++ b/src/app/core/utils/routes-article.js
@@ -18,7 +18,7 @@ export const getSubmissionOrArticleRoute = locationPathname => {
 }
 
 export const preloadConstructor = (loadedArticle, nextArticle) => {
-  console.log(nextArticle)
+  console.log(loadedArticle.slug, nextArticle.slug)
   if (loadedArticle.slug === nextArticle.slug) return loadedArticle
   return {
     status: "loading",

--- a/src/app/core/utils/routes-article.js
+++ b/src/app/core/utils/routes-article.js
@@ -1,3 +1,4 @@
+import { DOCUMENT_PLACEHOLDER } from "../constants/messages-article"
 import {
   ROUTE_API_ARTICLES,
   ROUTE_API_SUBMISSIONS,
@@ -13,5 +14,20 @@ export const getSubmissionOrArticleRoute = locationPathname => {
     apiRoute: locationPathname.includes(ROUTE_URL_SUBMISSIONS)
       ? ROUTE_API_SUBMISSIONS
       : ROUTE_API_ARTICLES
+  }
+}
+
+export const preloadConstructor = (loadedArticle, nextArticle) => {
+  console.log(nextArticle)
+  if (loadedArticle.slug === nextArticle.slug) return loadedArticle
+  return {
+    status: "loading",
+    title: nextArticle.title,
+    subtitle: nextArticle.subtitle,
+    tag: nextArticle.tag,
+    authors: nextArticle.authors,
+    slug: nextArticle.slug,
+    poster: nextArticle.poster,
+    content: DOCUMENT_PLACEHOLDER
   }
 }


### PR DESCRIPTION
- Refactor
- Compare states

There's still an edge case that causes old article to flash before new one overwrites it:
- Open list
- Open article 1
- Browser back to list
- Open article 1
- Open article 2 (article 1 will flash before article 2 loads)